### PR TITLE
Rich testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,232 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,windows,python
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,windows,python
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,windows,python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ipykernel
+pandas
+numpy
+matplotlib
+joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 numpy
 matplotlib
 joblib
+policy_priority_inference

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -7,7 +7,7 @@ There are four ways to setup PPI.
 
 ## Direct download
 
-1. Use Git to clone this repository to your local machine.
+1. Download the `tutorials` folder in your local machine.
 2. Open the Jupyter notebooks.
 3. Enjoy PPI.
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -3,11 +3,11 @@
 These tutorials assume that you have a basic knowledge of Python, and that you are familiar with the libraries Numpy and Pandas and their data structures (arrays and DataFrames).
 They are numbered in progressive order to take you from the data pre-processing steps, all the way to calibrating the model parameters and performing simulation experiments to detect structural bottlenecks.
 More tutorials will be added on demand.
-There are three ways to setup PPI.
+There are four ways to setup PPI.
 
 ## Direct download
 
-1. Download the `tutorials` folder in your local machine.
+1. Use Git to clone this repository to your local machine.
 2. Open the Jupyter notebooks.
 3. Enjoy PPI.
 
@@ -29,3 +29,10 @@ There are three ways to setup PPI.
 4. To avoid getting an error at this point, you need to create an empty folder named `clean_data` in the session that is running the tutorial.
 Alternatively, you can just comment the line that saves the file, as all the necessary data are always copied from this repository.
 5. Enjoy PPI.
+
+## Git clone
+
+1. Use Git to clone this repository to your local machine.
+2. Run `pip install -r requirements.txt`, preferably within a virtual environment of your choice. 
+3. Open the Jupyter notebooks.
+4. Enjoy PPI.


### PR DESCRIPTION
A couple of very minor updates to include requirements.txt and a template .gitignore:

* requirements, to help reproduce the environment used to run PPI. I have not pinned the versions but it may be preferable to do this, particularly for numpy and possibly matplotlib where breaking changes are frequently encountered.
* the .gitignore to help prevent the accidental commit of unintended files like .DS_Store on mac. The template comes from [toptal](https://www.toptal.com/developers/gitignore) which I frequently use to prepopulate gitignores dependent on the os and software used. For this project I selected mac-os, Windows & python-vanilla. 